### PR TITLE
Suporte ao Web of Science

### DIFF
--- a/BibFilesMerge.py
+++ b/BibFilesMerge.py
@@ -15,22 +15,22 @@ def mergeEntry(original, novo):
     global mergedCont
     merged = False
 
-    yearOut = int(original.fields['year'])
-    year2 = int(novo.fields['year'])
+    yearOut = int(str(original.rich_fields['year']))
+    year2 = int(str(novo.rich_fields['year']))
     if (year2>yearOut):
         original.fields['year'] = novo.fields['year']
         merged = True
 
-    for novoKey in novo.fields.keys():
-        if novoKey not in original.fields.keys():
+    for novoKey in novo.fields:
+        if novoKey not in original.fields:
             original.fields[novoKey] = novo.fields[novoKey]
             merged = True
 
     abs1 = ""
     abs2 = ""
-    if "abstract" in original.fields.keys():
+    if "abstract" in original.fields:
         abs1 = original.fields['abstract']
-    if "abstract" in novo.fields.keys():
+    if "abstract" in novo.fields:
         abs2 = novo.fields['abstract']
     if (len(abs2)>len(abs1)):
         original.fields['abstract'] = novo.fields['abstract']
@@ -66,11 +66,11 @@ def run(folderPath, fileList, fileNameOut):
         for entry in bibData.entries.values():
             total = total + 1
 
-            if not 'author' in entry.persons.keys():
+            if not 'author' in entry.persons:
                 withoutAuthor = withoutAuthor + 1
-            elif not 'year' in entry.fields.keys() or int(entry.fields['year'])==0:
+            elif not 'year' in entry.fields or int(str(entry.rich_fields['year']))==0:
                 withoutYear = withoutYear + 1
-            elif (not 'journal' in entry.fields.keys() ) and (not 'booktitle' in entry.fields.keys() ):
+            elif (not 'journal' in entry.fields ) and (not 'booktitle' in entry.fields ):
                 withoutJornal = withoutJornal + 1
             else:                
                 key =  entry.key.lower()
@@ -81,8 +81,8 @@ def run(folderPath, fileList, fileNameOut):
 
                 for entryOut in bibDataOut.entries.values():
                     if (entryOut.fields['title'].lower()==entry.fields['title'].lower()):
-                        year = int(entry.fields['year'])
-                        yearOut = int(entryOut.fields['year'])
+                        year = int(str(entry.rich_fields['year']))
+                        yearOut = int(str(entryOut.rich_fields['year']))
                         diff = abs(year-yearOut)
                         if (diff==0):
                             oldEntry = entryOut
@@ -135,7 +135,7 @@ def run(folderPath, fileList, fileNameOut):
     withoutAbstractList = {i: 0 for i in fileList}
     withoutAbstract = 0 
     for entry in bibDataOut.entries.values():
-        if not 'abstract' in entry.fields.keys():
+        if not 'abstract' in entry.fields:
             withoutAbstract = withoutAbstract + 1
             withoutAbstractList[entry.fields['source']] = withoutAbstractList[entry.fields['source']] + 1
 
@@ -160,7 +160,7 @@ print("-f ",args["fileList"])
 
 run(args["folderPath"], args["fileList"], args["fileNameOut"])
 
-#python BibFilesMerge.py -p "E:\Google Drive\Doutorado\Revisão Sistematica\resultados pesquisas" -o "MyFile.bib" -f IEEE.bib ACM.bib science.bib Springer.bib
+#python BibFilesMerge.py -p "Revisao\resultados pesquisas" -o "MyFile.bib" -f IEEE.bib ACM.bib science.bib Springer.bib
     
-#python BibFilesMerge.py -p "E:\Google Drive\Doutorado\Revisão Sistematica\resultados pesquisas" -f IEEE.bib ACM.bib science.bib Springer.bib -o "MyFile.bib" 
+#python BibFilesMerge.py -p "Revisao\resultados pesquisas" -f IEEE.bib ACM.bib science.bib Springer.bib -o "MyFile.bib" 
 


### PR DESCRIPTION
Os .bib exportados do Web of Science são um pouco diferentes do restante, notadamente: as linhas geralmente são quebradas antes de baterem em 80 caracteres (mas isso não é uma regra absoluta), os atributos tem a primeira letra em maiúscula ("Author", "Title", "Year"), os atributos numéricos são apresentados como "protected" (entre duas chaves), etc.

Percebi que todas as minhas referências da base Web of Science estavam sendo identificadas como "without Author". A causa era um mau uso da classe `pybtex.utils.OrderedCaseInsensitiveDict`: conforme o [exemplo](https://github.com/oseledets/pybtex/blob/master/pybtex/utils.py#L228) para que a comparação seja realmente case-insensitive não se deve usar o `.keys()`.

Após essa correção, as referências passaram a ser identificadas como "without Year" ou apresentar erro. A causa, neste caso, era porque o `entry.fields['year']` retorna `{2018}`, e o script tenta converter isso para `int`. Para corrigir, alterei para usar `entry.rich_fields['year']`, que retorna classes [rich text](https://docs.pybtex.org/api/styles.html#rich-text), que podem ser convertidas diretamente para string para obter o valor "puro".

Essas duas correções estão inclusas neste PR.

Testei com .bib do Web of Science, Science Direct, IEEE e Scopus.