### PR TITLE
Added --logProcess switch to create csv logs

### DIFF
--- a/BibFilesMerge.py
+++ b/BibFilesMerge.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 
@@ -42,10 +44,68 @@ def mergeEntry(original, novo):
 
     return original
 
+#=============================================================
+def getEntryDOIStr(entry):
+    doi = ""
+    if 'doi' in entry.fields:
+        doi = str(entry.rich_fields['doi'])
+    return doi
+
+def getEntryAuthorStr(entry):
+    author = ""
+    if 'author' in entry.persons:
+        author = ' and '.join([''.join(p.last()) + ', ' + ''.join(p.first()) for p in entry.persons['author']])
+    return author
+
+def getEntryYearStr(entry):
+    year = ""
+    if 'year' in entry.fields:
+        year = str(entry.rich_fields['year'])
+    return year
+
+def getEntryTitleStr(entry):
+    title = ""
+    if 'title' in entry.fields:
+        title = str(entry.rich_fields['title'])
+    return title
+
+def getEntryPublishStr(entry):
+    publish = ""
+    if 'journal' in entry.fields:
+        publish = str(entry.rich_fields['journal'])
+    elif 'journaltitle' in entry.fields:
+        publish = str(entry.rich_fields['journaltitle'])
+    elif 'booktitle' in entry.fields:
+        publish = str(entry.rich_fields['booktitle'])
+    elif 'howpublished' in entry.fields:
+        publish = str(entry.rich_fields['howpublished'])
+    elif 'type' in entry.fields:
+        publish = str(entry.rich_fields['type'])
+    elif 'url' in entry.fields:
+        publish = "URL {}".format(entry.fields['url'])
+    elif 'crossref' in entry.fields:
+        publish = entry.fields['crossref'].replace("_", " ")
+        publish = capwords(publish)
+    elif 'publisher' in entry.fields:
+        publish = str(entry.rich_fields['publisher'])
+    return publish
+
+def getEntryAbstractStr(entry):
+    abstract = ""
+    if 'abstract' in entry.fields:
+        abstract = str(entry.rich_fields['abstract'])
+    return abstract
+
 
 #=============================================================
-def run(folderPath, fileList, fileNameOut):
+def run(folderPath, fileList, fileNameOut, logProcess):
     global mergedCont
+
+    if logProcess:
+        fRemoved = open(os.path.join(folderPath, 'BibFilesMerge_removed.csv'),'w')
+        fRemoved.write("cause;source;key;doi;author;year;title;publish\n")
+        fFinal = open(os.path.join(folderPath, 'BibFilesMerge_final.csv'),'w')
+        fFinal.write("key;doi;author;year;title;publish;abstract\n")
 
     fileNamePathOut = os.path.join(folderPath, fileNameOut)
 
@@ -66,13 +126,32 @@ def run(folderPath, fileList, fileNameOut):
         for entry in bibData.entries.values():
             total = total + 1
 
+            if logProcess:
+                doi = getEntryDOIStr(entry)
+                author = getEntryAuthorStr(entry)
+                year = getEntryYearStr(entry)
+                title = getEntryTitleStr(entry)
+                publish = getEntryPublishStr(entry)
+
             if not 'author' in entry.persons:
                 withoutAuthor = withoutAuthor + 1
-            elif not 'year' in entry.fields or int(str(entry.rich_fields['year']))==0:
+                if logProcess:
+                    #cause;source;key;doi;author;year;title;publish
+                    fRemoved.write("{};{};{};{};{};{};{};{}\n".format("no author", bibFileName, entry.key, doi, author, year, title, publish))
+                
+            elif not 'year' in entry.fields or not str(entry.rich_fields['year']) or int(str(entry.rich_fields['year']))==0:
                 withoutYear = withoutYear + 1
+                if logProcess:
+                    #cause;source;key;doi;author;year;title;publish
+                    fRemoved.write("{};{};{};{};{};{};{};{}\n".format("no year", bibFileName, entry.key, doi, author, year, title, publish))
+                
             elif (not 'journal' in entry.fields ) and (not 'booktitle' in entry.fields ):
                 withoutJornal = withoutJornal + 1
-            else:                
+                if logProcess:
+                    #cause;source;key;doi;author;year;title;publish
+                    fRemoved.write("{};{};{};{};{};{};{};{}\n".format("no journal", bibFileName, entry.key, doi, author, year, title, publish))
+
+            else:
                 key =  entry.key.lower()
                 print("Key "+key+"               \r", end="", flush=True)
 
@@ -114,6 +193,18 @@ def run(folderPath, fileList, fileNameOut):
   
                 if (oldEntry != None):
                     duplicates = duplicates + 1
+
+                    if logProcess:
+                        #cause;source;key;doi;author;year;title;publish
+                        fRemoved.write("{};{};{};{};{};{};{};{}\n".format("duplicate of next", bibFileName, entry.key, doi, author, year, title, publish))
+
+                        doi = getEntryDOIStr(oldEntry)
+                        author = getEntryAuthorStr(oldEntry)
+                        year = getEntryYearStr(oldEntry)
+                        title = getEntryTitleStr(oldEntry)
+                        publish = getEntryPublishStr(oldEntry)
+                        fRemoved.write("{};{};{};{};{};{};{};{}\n".format("duplicate of prev", oldEntry.fields['source'], oldEntry.key, doi, author, year, title, publish))
+
                     bibDataOut.entries[oldEntry.key] = mergeEntry(oldEntry, entry)
 
                 else:
@@ -135,6 +226,17 @@ def run(folderPath, fileList, fileNameOut):
     withoutAbstractList = {i: 0 for i in fileList}
     withoutAbstract = 0 
     for entry in bibDataOut.entries.values():
+        if logProcess:
+            doi = getEntryDOIStr(entry)
+            author = getEntryAuthorStr(entry)
+            year = getEntryYearStr(entry)
+            title = getEntryTitleStr(entry)
+            publish = getEntryPublishStr(entry)
+            abstract = getEntryAbstractStr(entry)
+
+            #key;doi;author;year;title;publish;abstract
+            fFinal.write("{};{};{};{};{};{};{}\n".format(entry.key, doi, author, year, title, publish, abstract))
+
         if not 'abstract' in entry.fields:
             withoutAbstract = withoutAbstract + 1
             withoutAbstractList[entry.fields['source']] = withoutAbstractList[entry.fields['source']] + 1
@@ -143,6 +245,9 @@ def run(folderPath, fileList, fileNameOut):
 
     bibDataOut.to_file(fileNamePathOut)
 
+    if logProcess:
+        fRemoved.close()
+        fFinal.close()
 
 
 #=============================================================================
@@ -151,14 +256,16 @@ ap = argparse.ArgumentParser()
 ap.add_argument("-p", "--folderPath", required=True, help="Bib files folder path")
 ap.add_argument("-f", "--fileList", nargs='*', required=False, help='bib file name list, e.g. -files IEEE.bib ACM.bib science.bib Springer.bib')
 ap.add_argument("-o", "--fileNameOut", required=False, help="File name of merged file")
+ap.add_argument("-l", "--logProcess", required=False, help="Log processing to csv files", action='store_true')
 
 args = vars(ap.parse_args())
 
-print("-p ",args["folderPath"])
-print("-o ",args["fileNameOut"])
-print("-f ",args["fileList"])
+print("--folderPath\t",args["folderPath"])
+print("--fileNameOut\t",args["fileNameOut"])
+print("--fileList\t",args["fileList"])
+print("--logProcess\t",args["logProcess"])
 
-run(args["folderPath"], args["fileList"], args["fileNameOut"])
+run(args["folderPath"], args["fileList"], args["fileNameOut"], args["logProcess"])
 
 #python BibFilesMerge.py -p "Revisao\resultados pesquisas" -o "MyFile.bib" -f IEEE.bib ACM.bib science.bib Springer.bib
     

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ python GetAbstract.py -d springer -f "E:\Google Drive\Doutorado\Revisão Sistema
 
 Merge BibText files and:
 - remove duplicate entries 
-- in some cases before removing duplicates
+- in some cases merge information before removing duplicates
 - remove entries that not have:
     - author or
     - title or 
     - year or 
-    - jornal name or conference name
+    - journal name or conference name
 
 This tool has been tested with digital library files:
 - ACM Digital Library     
@@ -96,7 +96,7 @@ This tool has been tested with digital library files:
 - Scopus                  
 - SpringerLink            
 - ScienceDirect - ElsevierWeb of Science
-- Web of Science (Thanks Dinei André Rockenbach for this)
+- Web of Science (thanks [@dineiar](https://github.com/dineiar) for this)
 
 
 
@@ -104,7 +104,7 @@ This tool has been tested with digital library files:
 ```
 python BibFilesMerge.py -h
 usage: BibFilesMerge.py [-h] -p FOLDERPATH [-f [FILELIST [FILELIST ...]]]
-                        [-o FILENAMEOUT]
+                        [-o FILENAMEOUT] [-l]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -115,11 +115,13 @@ optional arguments:
                         science.bib Springer.bib
   -o FILENAMEOUT, --fileNameOut FILENAMEOUT
                         File name of merged file
+  -l, --logProcess      Record merged and final references to CSV files 
+                        on FOLDERPATH
 ```
 
 Example:
 
-python BibFilesMerge.py -p "E:\Google Drive\Doutorado\Revisão Sistematica\resultados pesquisas" -o MyFile.bib -f IEEE.bib ACM.bib science.bib Springer.bib scopus.bib
+python BibFilesMerge.py -p "output_folder" -o MyFile.bib -f IEEE.bib ACM.bib science.bib Springer.bib scopus.bib -l
 
 >Total  3253  
 >without Author  65  
@@ -129,10 +131,12 @@ python BibFilesMerge.py -p "E:\Google Drive\Doutorado\Revisão Sistematica\resul
 >Final  2270  
 >without Abstract  746  
 
+The two CSV files created on `output_folder` by the `-l` switch.
+
 ### Load Bib File Error
 
 Sometimes errors occur while reading the bib file.   
-In this case, note at the end of the error the error line of the bib file.   
+In this case, note at the end of the error line of the bib file.   
 Then edit the bib file and adjust the error.   
 
 **Error, see the last line**:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ optional arguments:
                         science.bib Springer.bib
   -o FILENAMEOUT, --fileNameOut FILENAMEOUT
                         File name of merged file
-  -l, --logProcess      Record merged and final references to CSV files 
+  -l, --logProcess      List merged and final references to CSV files 
                         on FOLDERPATH
 ```
 
@@ -131,7 +131,10 @@ python BibFilesMerge.py -p "output_folder" -o MyFile.bib -f IEEE.bib ACM.bib sci
 >Final  2270  
 >without Abstract  746  
 
-The two CSV files created on `output_folder` by the `-l` switch.
+The two CSV files created on `output_folder` by the `-l` switch are:
+- `BibFilesMerge_removed.csv`, with columns cause, source, key, doi, author, year, title and publish
+    - cause is one of: no author, no year, no journal, duplicate of next or duplicate of prev
+- `BibFilesMerge_final.csv`, with columns key, doi, author, year, title, publish and abstract
 
 ### Load Bib File Error
 


### PR DESCRIPTION
I needed some csv listing to check the final list of papers. Instead of creating yet another script to convert the output of BibFilesMerge to csv, I added a bool parameter (-l or --logProcess) to create csv listings of the final and merged papers.

Some minor improvements include a comment on the first line do allow the execution of the script with `./BibFilesMerge.py` and printing the full name of the parameters on the script starting.